### PR TITLE
Fix: Patch removal check

### DIFF
--- a/core/src/state/patches.ts
+++ b/core/src/state/patches.ts
@@ -25,7 +25,7 @@ class Patches {
     this.patches.update(($patches) => {
       return $patches.filter(($patch) => {
         if (!input) {
-          return $patch.input.indexOf(output) !== 0 && $patch.output.indexOf(output) !== 0;
+          return $patch.input?.indexOf(output) !== 0 && $patch.output?.indexOf(output) !== 0;
         }
         return !($patch.input === input && $patch.output === output);
       });


### PR DESCRIPTION
Checks against possible undefined `input` or `output` results in error when connecting `input` to `input` or `output` to `output`.