### PR TITLE
Fix Vercel development build

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -219,6 +219,6 @@
     "svelteSortOrder": "options-scripts-styles-markup"
   },
   "devDependencies": {
-    "@patchcab/core": "1.0.5"
+    "@patchcab/core": "1.1.1"
   }
 }

--- a/modules/package.json
+++ b/modules/package.json
@@ -219,6 +219,6 @@
     "svelteSortOrder": "options-scripts-styles-markup"
   },
   "devDependencies": {
-    "@patchcab/core": "1.1.1"
+    "@patchcab/core": "1.0.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "modules"
   ],
   "scripts": {
-    "build": "yarn --cwd ./core build && yarn --cwd ./modules && yarn --cwd ./modules build && cpy './modules/public/modules.json' './core/public/' && cpy './modules/public/modules' './core/public/modules/@patchcab-modules'"
+    "build": "yarn --cwd ./core build && yarn --cwd ./modules install --focus && yarn --cwd ./modules build && cpy './modules/public/modules.json' './core/public/' && cpy './modules/public/modules' './core/public/modules/@patchcab-modules'"
   },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "modules"
   ],
   "scripts": {
-    "build": "yarn --cwd ./core build && yarn --cwd ./modules build && cpy './modules/public/modules.json' './core/public/' && cpy './modules/public/modules' './core/public/modules/@patchcab-modules'"
+    "build": "yarn --cwd ./core build && yarn --cwd ./modules && yarn --cwd ./modules build && cpy './modules/public/modules.json' './core/public/' && cpy './modules/public/modules' './core/public/modules/@patchcab-modules'"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
Fix Vercel development build by adding `yarn --focus` dependency installation command.
Fixes #16 